### PR TITLE
feat: package for luarocks

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,16 @@
+name: "luarocks"
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          template: rockspec.template

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ See:
 
 ## Installation
 
+### Using luarocks
+
+[![][luarocks-shield]][luarocks-url]
+
+This package is available on [luarocks].
+
+```
+luarocks install --local nlua
+```
+
+### Manually
+
 For [luarocks] support, copy or symlink `nlua` to `/usr/bin/`
 If you don't need [luarocks] support, copy it into any folder in your `$PATH`.
 
@@ -64,7 +76,8 @@ If you don't need [luarocks] support, copy it into any folder in your `$PATH`.
 lua_interpreter = "nlua"
 lua_version = "5.1"
 variables = {
-   LUA_INCDIR = "/usr/include/luajit-2.1"
+   LUA_INCDIR = "/usr/include/luajit-2.1",
+   LUA_BINDIR = "$HOME/.luarocks/bin", -- path to where nlua is installed
 }
 ```
 
@@ -86,3 +99,5 @@ nluarocks install busted
 [luarocks]: https://luarocks.org/
 [busted]: https://lunarmodules.github.io/busted/
 [local-lua-debugger-vscode]: https://github.com/tomblind/local-lua-debugger-vscode
+[luarocks-shield]: https://img.shields.io/luarocks/v/mfussenegger/nlua?logo=lua&color=purple&style=for-the-badge
+[luarocks-pkg-url]: https://luarocks.org/modules/mfussenegger/nlua

--- a/rockspec.template
+++ b/rockspec.template
@@ -1,0 +1,39 @@
+local git_ref = '$git_ref'
+local modrev = '$modrev'
+local specrev = '$specrev'
+
+local repo_url = '$repo_url'
+
+rockspec_format = '3.0'
+package = '$package'
+version = modrev ..'-'.. specrev
+
+description = {
+  summary = '$summary',
+  detailed = [[
+    Neovim embeds a Lua interpreter, but it doesn't expose the same command line interface as plain lua.
+    nlua is a script which emulates Lua's command line interface, using Neovim's -l option under the hood.
+  ]],
+  labels = $labels,
+  homepage = '$homepage',
+  $license
+}
+
+dependencies = $dependencies
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = '$repo_name-' .. '$archive_dir_suffix',
+}
+
+deploy = {
+    wrap_bin_scripts = false,
+}
+
+build = {
+   type = "builtin",
+   modules = {},
+   install = {
+     bin = { nlua = 'nlua', },
+   },
+}


### PR DESCRIPTION
Closes #1.

This requires a `LUAROCKS_API_KEY` to be added to this repo's GitHub Actions secrets [(as you did for nvim-dap)](https://github.com/mfussenegger/nvim-dap/pull/855). :smile: 

It might be interesting to also package a `nluarocks` wrapper in a similar fashion.
If you're open to it, I can do that in a follow-up PR when I have some more time. Alternatively, that could also be a separate luarocks package that depends on this one.