### PR TITLE
Some rockspec fixes

### DIFF
--- a/nlua-scm-1.rockspec
+++ b/nlua-scm-1.rockspec
@@ -10,6 +10,10 @@ deploy = {
     wrap_bin_scripts = false,
 }
 
+dependencies = {
+    "lua == 5.1",
+}
+
 test_dependencies = {
     "nlua"
 }

--- a/rockspec.template
+++ b/rockspec.template
@@ -19,7 +19,9 @@ description = {
   $license
 }
 
-dependencies = $dependencies
+dependencies = {
+  'lua == 5.1',
+}
 
 source = {
   url = repo_url .. '/archive/' .. git_ref .. '.zip',

--- a/rockspec.template
+++ b/rockspec.template
@@ -38,4 +38,14 @@ build = {
    install = {
      bin = { nlua = 'nlua', },
    },
+   platforms = {
+     win32 = {
+       install = {
+         bin = { 
+          nlua = 'nlua', 
+          ['nlua.bat'] = 'nlua.bat',
+         },
+       },
+     }
+   },
 }


### PR DESCRIPTION
- Fixes #15 - I forgot to add the new `build` table to the release rockspec template.
- Sets the Lua version constraint to `==5.1`. See https://github.com/nvim-neorocks/lux/issues/715#issuecomment-2895873648 for details about this.